### PR TITLE
docs: add Ubiquiti UniFi RTSPS stream URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Replace `[IP]` with your camera's IP address and `[PASS]` with its password. Def
 | **D-Link** | Main | `rtsp://admin:[PASS]@[IP]:554/live1.sdp` |
 | **Wyze** | Main | `rtsp://admin:[PASS]@[IP]:554/live` |
 | **Ctronic** | Main | `rtsp://admin:[PASS]@[IP]:554/11` |
+| **Ubiquiti UniFi** | Main | `rtsps://[IP]:[RTSPS_PORT]/[RTSP_ALIAS]?enableSrtp` |
 
 > **Not listed?** Search `"[your camera brand] RTSP URL"`, or test your stream in **VLC** → *Media → Open Network Stream*.
 >


### PR DESCRIPTION
**Summary**
This PR adds Ubiquiti UniFi to the Camera RTSP URL Reference in the README.md. including the correct RTSPS format used by UniFi Protect.

**What changed**
Added a new camera entry for Ubiquiti UniFi in
Documented the stream format as: rtsps://[IP]:[RTSPS_PORT]/[RTSP_ALIAS]?enableSrtp

**Why**
Users requested official UniFi stream guidance, and the previous placeholder was too generic.
This update provides a clearer, production-usable format and reduces setup confusion.

**Validation**
This format has been tested and confirmed working with our UniFi Protect setup on Ubiquiti hardware.

**Tested hardware:**
- Ubiquiti G6 PTZ (UVC-G6-PTZ)
- Ubiquiti G6 Pro Turret (UVC-G6-Pro-Turret-B)
- Ubiquiti G6 Pro Bullet (UVC-G6-Pro-Bullet-B)
- Ubiquiti  G6 Bullet (UVC-G6-Bullet-B)

**Impact**
Documentation-only change
No code or runtime behavior changes
Improves setup success rate for UniFi users